### PR TITLE
Allow portable agent to run multiple test assemblies

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview2-003121"
+    "version": "1.0.0-preview2-003131"
   }
 }

--- a/src/NUnit.Portable.Agent/NUnitPortableDriver.cs
+++ b/src/NUnit.Portable.Agent/NUnitPortableDriver.cs
@@ -35,23 +35,19 @@ namespace NUnit.Engine
     /// </summary>
     public class NUnitPortableDriver
     {
-        const string LOAD_MESSAGE = "Method called without calling Load first";
-        const string INVALID_FRAMEWORK_MESSAGE = "Running tests against this version of the framework using this driver is not supported. Please update NUnit.Framework to the latest version.";
+        internal const string INVALID_FRAMEWORK_MESSAGE = "Running tests against this version of the framework using this driver is not supported. Please update NUnit.Framework to the latest version.";
+        private const string LOAD_MESSAGE = "Method called without loading any assemblies";
+    
+        private const string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
+        private const string LOAD_METHOD = "LoadTests";
+        private const string EXPLORE_METHOD = "ExploreTests";
+        private const string COUNT_METHOD = "CountTests";
+        private const string RUN_METHOD = "RunTests";
+        private const string RUN_ASYNC_METHOD = "RunTests";
+        private const string STOP_RUN_METHOD = "StopRun";
 
-        static readonly string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
-        static readonly string LOAD_METHOD = "LoadTests";
-        static readonly string EXPLORE_METHOD = "ExploreTests";
-        static readonly string COUNT_METHOD = "CountTests";
-        static readonly string RUN_METHOD = "RunTests";
-        static readonly string RUN_ASYNC_METHOD = "RunTests";
-        static readonly string STOP_RUN_METHOD = "StopRun";
-
-        static ILogger log = InternalTrace.GetLogger("NUnit3PortableDriver");
-
-        Assembly _testAssembly;
-        Assembly _frameworkAssembly;
-        object _frameworkController;
-        Type _frameworkControllerType;
+        private static readonly ILogger log = InternalTrace.GetLogger("NUnit3PortableDriver");
+        private readonly List<TestAssemblyWrapper> _testWrappers = new List<TestAssemblyWrapper>();
 
         /// <summary>
         /// An id prefix that will be passed to the test framework and used as part of the
@@ -69,17 +65,15 @@ namespace NUnit.Engine
         public string Load(Assembly frameworkAssembly, Assembly testAssembly, IDictionary<string, object> settings)
         {
             var idPrefix = string.IsNullOrEmpty(ID) ? "" : ID + "-";
-            _frameworkAssembly = frameworkAssembly;
-            _testAssembly = testAssembly;
-
-            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssembly, idPrefix, settings);
-            if (_frameworkController == null)
+            var frameworkController = CreateObject(CONTROLLER_TYPE, frameworkAssembly, testAssembly, idPrefix, settings);
+            if (frameworkController == null)
                 throw new NUnitPortableDriverException(INVALID_FRAMEWORK_MESSAGE);
 
-            _frameworkControllerType = _frameworkController.GetType();
+            var testWrapper = new TestAssemblyWrapper(testAssembly, frameworkController);
+            _testWrappers.Add(testWrapper);
 
-            log.Info("Loading {0} - see separate log file", _testAssembly.FullName);
-            return ExecuteMethod(LOAD_METHOD) as string;
+            log.Info("Loading {0} - see separate log file", testAssembly.FullName);
+            return testWrapper.ExecuteMethod(LOAD_METHOD) as string;
         }
 
         /// <summary>
@@ -89,9 +83,18 @@ namespace NUnit.Engine
         /// <returns>The number of test cases</returns>
         public int CountTestCases(string filter)
         {
-            CheckLoadWasCalled();
-            object count = ExecuteMethod(COUNT_METHOD, filter);
-            return count != null ? (int)count : 0;
+            CheckAssembliesLoaded();
+
+            var count = 0;
+
+            foreach (var wrapper in _testWrappers)
+            {
+                object assemblyCount = wrapper.ExecuteMethod(COUNT_METHOD, filter);
+                if (assemblyCount is int)
+                    count += (int)assemblyCount;
+            }
+
+            return count;
         }
 
         /// <summary>
@@ -102,9 +105,11 @@ namespace NUnit.Engine
         /// <returns>An Xml string representing the result</returns>
         public string Run(Action<string> callback, string filter)
         {
-            CheckLoadWasCalled();
-            log.Info("Running {0} - see separate log file", _testAssembly.FullName);
-            return ExecuteMethod(RUN_METHOD, new[] { typeof(Action<string>), typeof(string) }, callback, filter) as string;
+            CheckAssembliesLoaded();
+
+            Func<TestAssemblyWrapper, string> runTestsAction =
+                p => p.ExecuteMethod(RUN_METHOD, new[] {typeof(Action<string>), typeof(string)}, callback, filter) as string;
+            return SummarizeResults("Running", runTestsAction);
         }
 
         /// <summary>
@@ -114,18 +119,23 @@ namespace NUnit.Engine
         /// <param name="filter">A filter that controls which tests are executed</param>
         public void RunAsync(Action<string> callback, string filter)
         {
-            CheckLoadWasCalled();
-            log.Info("Running {0} - see separate log file", _testAssembly.FullName);
-            ExecuteMethod(RUN_ASYNC_METHOD, new[] { typeof(Action<string>), typeof(string) }, callback, filter);
+            CheckAssembliesLoaded();
+
+            foreach (var assembly in _testWrappers)
+            {
+                log.Info("Running {0} - see separate log file", assembly.FullName);
+                assembly.ExecuteMethod(RUN_ASYNC_METHOD, new[] { typeof(Action<string>), typeof(string) }, callback, filter);
+            }
         }
 
         /// <summary>
-        /// Cancel the ongoing test run. If no  test is running, the call is ignored.
+        /// Cancel the ongoing test run. If no test is running, the call is ignored.
         /// </summary>
         /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
         public void StopRun(bool force)
         {
-            ExecuteMethod(STOP_RUN_METHOD, force);
+            foreach (var assembly in _testWrappers)
+                assembly.ExecuteMethod(STOP_RUN_METHOD, force);
         }
 
         /// <summary>
@@ -135,50 +145,41 @@ namespace NUnit.Engine
         /// <returns>An Xml string representing the tests</returns>
         public string Explore(string filter)
         {
-            CheckLoadWasCalled();
+            CheckAssembliesLoaded();
 
-            log.Info("Exploring {0} - see separate log file", _testAssembly.FullName);
-            return ExecuteMethod(EXPLORE_METHOD, filter) as string;
+            Func<TestAssemblyWrapper, string> exploreTestsAction = p => p.ExecuteMethod(EXPLORE_METHOD, filter) as string;
+            return SummarizeResults("Exploring", exploreTestsAction);
         }
 
         #region Helper Methods
 
-        void CheckLoadWasCalled()
+        private string SummarizeResults(string logTask, Func<TestAssemblyWrapper, string> testAction)
         {
-            if (_frameworkController == null)
+            var summary = new ResultSummary();
+            foreach (var assembly in _testWrappers)
+            {
+
+                log.Info("{0} {1} - see separate log file", logTask, assembly.FullName);
+                summary.AddResult(testAction(assembly));
+            }
+            return summary.GetTestResults().ToString();
+        }
+
+        private void CheckAssembliesLoaded()
+        {
+            if (_testWrappers.Count == 0)
                 throw new InvalidOperationException(LOAD_MESSAGE);
         }
 
-        object CreateObject(string typeName, params object[] args)
+        private static object CreateObject(string typeName, Assembly frameworkAssembly, params object[] args)
         {
-            var typeinfo = _frameworkAssembly.DefinedTypes.FirstOrDefault(t => t.FullName == typeName);
+            var typeinfo = frameworkAssembly.DefinedTypes.FirstOrDefault(t => t.FullName == typeName);
             if (typeinfo == null)
             {
                 log.Error("Could not find type {0}", typeName);
+                return null;
             }
             return Activator.CreateInstance(typeinfo.AsType(), args);
-        }
-
-        object ExecuteMethod(string methodName, params object[] args)
-        {
-            //var method = _frameworkControllerType.GetMethod(methodName, BindingFlags.Public);
-            var method = _frameworkControllerType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
-            return ExecuteMethod(method, args);
-        }
-
-        object ExecuteMethod(string methodName, Type[] ptypes, params object[] args)
-        {
-            var method = _frameworkControllerType.GetMethod(methodName, ptypes);
-            return ExecuteMethod(method, args);
-        }
-
-        object ExecuteMethod(MethodInfo method, params object[] args)
-        {
-            if (method == null)
-            {
-                throw new NUnitPortableDriverException(INVALID_FRAMEWORK_MESSAGE);
-            }
-            return method.Invoke(_frameworkController, args);
         }
 
         #endregion

--- a/src/NUnit.Portable.Agent/ResultSummary.cs
+++ b/src/NUnit.Portable.Agent/ResultSummary.cs
@@ -81,13 +81,16 @@ namespace NUnit.Engine
             var test = new XElement("test-run");
             test.Add(new XAttribute("id", "0"));
             test.Add(new XAttribute("testcasecount", TestCount));
-            test.Add(new XAttribute("result", Result));
             test.Add(new XAttribute("total", TestCount));
             test.Add(new XAttribute("passed", PassCount));
             test.Add(new XAttribute("failed", FailedCount));
             test.Add(new XAttribute("inconclusive", InconclusiveCount));
             test.Add(new XAttribute("skipped", TotalSkipCount));
             test.Add(new XAttribute("asserts", AssertCount));
+
+            //Occurs when summarizing explore only
+            if (Result != null)
+                test.Add(new XAttribute("result", Result));
 
             test.Add(new XAttribute("portable-engine-version", typeof(ResultSummary).GetTypeInfo().Assembly.GetName().Version.ToString()));
 

--- a/src/NUnit.Portable.Agent/TestAssemblyWrapper.cs
+++ b/src/NUnit.Portable.Agent/TestAssemblyWrapper.cs
@@ -1,0 +1,64 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Reflection;
+
+namespace NUnit.Engine
+{
+    internal class TestAssemblyWrapper
+    {
+        private readonly Assembly _testAssembly;
+        private readonly object _frameworkController;
+
+        private Type FrameworkControllerType => _frameworkController.GetType();
+        public string FullName => _testAssembly.FullName;
+
+        internal TestAssemblyWrapper(Assembly testAssembly, object frameworkController)
+        {
+            _testAssembly = testAssembly;
+            _frameworkController = frameworkController;
+        }
+
+        internal object ExecuteMethod(string methodName, params object[] args)
+        {
+            var method = FrameworkControllerType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            return ExecuteMethod(method, args);
+        }
+
+        internal object ExecuteMethod(string methodName, Type[] ptypes, params object[] args)
+        {
+            var method = FrameworkControllerType.GetMethod(methodName, ptypes);
+            return ExecuteMethod(method, args);
+        }
+
+        private object ExecuteMethod(MethodInfo method, params object[] args)
+        {
+            if (method == null)
+            {
+                throw new NUnitPortableDriverException(NUnitPortableDriver.INVALID_FRAMEWORK_MESSAGE);
+            }
+            return method.Invoke(_frameworkController, args);
+        }
+    }
+}

--- a/test/NUnit.Portable.Agent.Tests/Compatibility/AttributeHelperTests.cs
+++ b/test/NUnit.Portable.Agent.Tests/Compatibility/AttributeHelperTests.cs
@@ -136,7 +136,9 @@ namespace NUnit.Engine.Tests.Compatibility
             public int MyProperty { get; set; }
 
             [Datapoint]
+#pragma warning disable 169
             public int field = 1;
+#pragma warning restore 169
         }
 
         class B : A

--- a/test/NUnit.Portable.Agent.Tests/MultipleAssemblyTests.cs
+++ b/test/NUnit.Portable.Agent.Tests/MultipleAssemblyTests.cs
@@ -1,0 +1,99 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using NUnit.Framework;
+using NUnit.Tests.Assemblies;
+
+namespace NUnit.Engine.Tests
+{
+    public class MultipleAssemblyTests
+    {
+        const string EMPTY_FILTER = "<filter />";
+        private readonly IDictionary<string, object> _settings = new Dictionary<string, object>();
+
+        private Assembly _mockAssembly;
+        private Assembly _frameworkAssembly;
+        private NUnitPortableDriver _driver;
+
+
+        [SetUp]
+        public void CreateDriver()
+        {
+            _mockAssembly = typeof(MockAssembly).GetTypeInfo().Assembly;
+            _frameworkAssembly = typeof(Assert).GetTypeInfo().Assembly;
+            _driver = new NUnitPortableDriver();
+        }
+
+        [Test]
+        public void LoadReturnsSingleNodePerAssembly()
+        {
+            for (int i = 0; i < 2; i++)
+            {
+                var result = XmlHelper.CreateXElement(_driver.Load(_frameworkAssembly, _mockAssembly, _settings));
+                Assert.That(result.Name.LocalName, Is.EqualTo("test-suite"));
+                Assert.That(result.GetAttribute("type"), Is.EqualTo("Assembly"));
+                Assert.That(result.GetAttribute("runstate"), Is.EqualTo("Runnable"));
+            }
+        }
+
+        [Test]
+        public void ExploreTestsAction_AfterLoadMultipleAssemblies_ReturnsAllSuites()
+        {
+            LoadMultipleAssemblies();
+            var result = XmlHelper.CreateXElement(_driver.Explore(EMPTY_FILTER));
+            Assert.That(result.Name.LocalName, Is.EqualTo("test-run"));
+            Assert.That(result.Elements(XName.Get("test-suite")).Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void CountTestsAction_AfterLoadMultipleAssemblies_ReturnsCorrectCount()
+        {
+            LoadMultipleAssemblies();
+            Assert.That(_driver.CountTestCases(EMPTY_FILTER), Is.EqualTo(2 * MockAssembly.Tests));
+        }
+
+        [Test]
+        public void RunTestsAction_AfterLoadMultipleAssemblies_RunsAllAssemblies()
+        {
+            LoadMultipleAssemblies();
+            var result = XmlHelper.CreateXElement(_driver.Run(null, EMPTY_FILTER));
+
+            Assert.That(result.Name.LocalName, Is.EqualTo("test-run"));
+            var testSuites = result.Elements(XName.Get("test-suite")).ToList();
+            Assert.That(testSuites, Has.Count.EqualTo(2));
+
+            foreach (var suite in testSuites)
+                Assert.That(suite.GetAttribute("runstate"), Is.EqualTo("Runnable"));
+        }
+
+        private void LoadMultipleAssemblies()
+        {
+            _driver.Load(_frameworkAssembly, _mockAssembly, _settings);
+            _driver.Load(_frameworkAssembly, _mockAssembly, _settings);
+        }
+    }
+}

--- a/test/NUnit.Portable.Agent.Tests/project.json
+++ b/test/NUnit.Portable.Agent.Tests/project.json
@@ -40,6 +40,5 @@
     "mock-assembly": {
       "target": "project"
     },
-    "NUnitLite": "3.4.0"
-  }
+    "NUnitLite": "3.5.0"  }
 }

--- a/test/mock-assembly/project.json
+++ b/test/mock-assembly/project.json
@@ -27,6 +27,6 @@
     "NUnit.Portable.Agent": {
       "target": "project"
     },
-    "NUnit": "3.4.0"
+    "NUnit": "3.5.0"
   }
 }


### PR DESCRIPTION
This is a checkpoint PR, for some feedback on a few points before tidying up for merge. (Fixes #13)

@rprouse, @CharliePoole - I'm going to put some specific questions in line comments, but would appreciate feedback on the general approach - this isn't a part of NUnit I'm too familiar with! The intention is to run assemblies in serial for now.

**Still to-do**
- [x] Decide on behaviour of Load methods
- [x] Additional per-method tests (current test is just to check it was actually working!)
- [x] Decide on behaviour of async running
