### PR TITLE
Handle duplicate test-run elements in ResultSummary

### DIFF
--- a/src/NUnit.Portable.Agent/ResultSummary.cs
+++ b/src/NUnit.Portable.Agent/ResultSummary.cs
@@ -102,8 +102,14 @@ namespace NUnit.Engine
             test.Add(new XAttribute("duration", Duration.ToString("0.000000", NumberFormatInfo.InvariantInfo)));
 
             foreach (var result in _results)
-                test.Add(result);
-            
+            {
+                XElement firstSuite = result.Name.LocalName == "test-run"
+                    ? result.Element(XName.Get("test-suite"))
+                    : result;
+
+                if (firstSuite != null) test.Add(firstSuite);
+            }
+
             return new XDocument(test);
         }
 

--- a/test/NUnit.Portable.Agent.Tests/ResultSummaryTests.cs
+++ b/test/NUnit.Portable.Agent.Tests/ResultSummaryTests.cs
@@ -119,5 +119,15 @@ namespace NUnit.Engine.Tests
             Assert.That(actualSkipped, Is.EqualTo(expectedSkipped));
             Assert.That(actualAsserts, Is.EqualTo(expectedAsserts));
         }
+
+        [Test]
+        public void MultipleTestRunsAreSummarizedCorrectly()
+        {
+            var summary = new ResultSummary();
+            summary.AddResult(_testRun);
+            summary.AddResult(_testRun);
+            var result = summary.GetTestResults();
+            Assert.That(result.Descendants(XName.Get("test-run")).ToList(), Has.Count.EqualTo(1));
+        }
     }
 }


### PR DESCRIPTION
Part of the fix for https://github.com/nunit/dotnet-test-nunit/issues/86 - the runner will then need to be updated to use this.

ResultSummary doesn't correctly handle multiple `test-run` nodes. I didn't notice this at first as it has functionality to handle them in `Summarize(XElement element)` - but it's missing additional functionality in `GetTestResults()`.